### PR TITLE
Enhancements - build updates

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 mkdocs:
   configuration: mkdocs.yml

--- a/CloudFormation/Manual/PSGalleryPipeline.yml
+++ b/CloudFormation/Manual/PSGalleryPipeline.yml
@@ -43,8 +43,9 @@ Parameters:
     Default: LINUX_CONTAINER
     Description: The type of build environment.
     AllowedValues:
+      - WINDOWS_SERVER_2022_CONTAINER
       - WINDOWS_SERVER_2019_CONTAINER
-      - WINDOWS_CONTAINER
+      - WINDOWS_EC2
       - LINUX_CONTAINER
 
   # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html
@@ -65,7 +66,7 @@ Parameters:
     AllowedValues:
       - aws/codebuild/standard:7.0
       - aws/codebuild/amazonlinux2-x86_64-standard:5.0
-      - aws/codebuild/windows-base:2019-2.0
+      - aws/codebuild/windows-base:2022-1.0
 
   ResourceType:
     Type: String

--- a/CloudFormation/Manual/PowerShellCodeBuildGit.yml
+++ b/CloudFormation/Manual/PowerShellCodeBuildGit.yml
@@ -281,8 +281,8 @@ Resources:
       Environment:
         # Certificate:
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Type: WINDOWS_SERVER_2019_CONTAINER
-        Image: aws/codebuild/windows-base:2019-2.0
+        Type: WINDOWS_SERVER_2022_CONTAINER
+        Image: aws/codebuild/windows-base:2022-1.0
         # EnvironmentVariables:
         #   - Name: ARTIFACT_S3_BUCKET
         #     Value: !Ref something
@@ -386,8 +386,8 @@ Resources:
       Environment:
         # Certificate:
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Type: WINDOWS_SERVER_2019_CONTAINER
-        Image: aws/codebuild/windows-base:2019-2.0
+        Type: WINDOWS_SERVER_2022_CONTAINER
+        Image: aws/codebuild/windows-base:2022-1.0
         # EnvironmentVariables:
         #   - Name: ARTIFACT_S3_BUCKET
         #     Value: !Ref something
@@ -491,8 +491,8 @@ Resources:
       Environment:
         # Certificate:
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Type: WINDOWS_SERVER_2019_CONTAINER
-        Image: aws/codebuild/windows-base:2019-2.0
+        Type: WINDOWS_SERVER_2022_CONTAINER
+        Image: aws/codebuild/windows-base:2022-1.0
         # EnvironmentVariables:
         #   - Name: ARTIFACT_S3_BUCKET
         #     Value: !Ref something
@@ -596,8 +596,8 @@ Resources:
       Environment:
         # Certificate:
         ComputeType: BUILD_GENERAL1_MEDIUM
-        Type: WINDOWS_SERVER_2019_CONTAINER
-        Image: aws/codebuild/windows-base:2019-2.0
+        Type: WINDOWS_SERVER_2022_CONTAINER
+        Image: aws/codebuild/windows-base:2022-1.0
         # EnvironmentVariables:
         #   - Name: ARTIFACT_S3_BUCKET
         #     Value: !Ref something

--- a/CodeBuild/IntegrationTest/buildspec.yml
+++ b/CodeBuild/IntegrationTest/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      dotnet: 8.0
     commands:
       - echo Configure AWS defaults using the configuration script added to the Docker Image.
       - pwsh -command './CodeBuild/configure_aws_credential.ps1'

--- a/CodeBuild/UnitTestAndBuild/buildspec.yml
+++ b/CodeBuild/UnitTestAndBuild/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      dotnet: 8.0
       # python: 3.8
     commands:
       # Check PowerShell Version

--- a/CodeBuild/install_modules.ps1
+++ b/CodeBuild/install_modules.ps1
@@ -45,7 +45,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.23.0'
+            ModuleVersion = '1.24.0'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))

--- a/CodeBuild/install_modules.ps1
+++ b/CodeBuild/install_modules.ps1
@@ -33,19 +33,19 @@ $VerbosePreference = 'SilentlyContinue'
 $modulesToInstall = [System.Collections.ArrayList]::new()
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.5.0'
+            ModuleVersion = '5.7.1'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.12.1'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.21.0'
+            ModuleVersion = '1.23.0'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
@@ -57,37 +57,37 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PoshGram'
-            ModuleVersion = '2.3.0'
+            ModuleVersion = '3.0.1'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'AWSLambdaPSCore'
-            ModuleVersion = '3.0.1.0'
+            ModuleVersion = '4.0.4.0'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'AWS.Tools.Common'
-            ModuleVersion = '4.1.472'
+            ModuleVersion = '5.0.3'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'AWS.Tools.CloudFormation'
-            ModuleVersion = '4.1.472'
+            ModuleVersion = '5.0.3'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'AWS.Tools.S3'
-            ModuleVersion = '4.1.472'
+            ModuleVersion = '5.0.3'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'AWS.Tools.SimpleSystemsManagement'
-            ModuleVersion = '4.1.472'
+            ModuleVersion = '5.0.3'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Jake Morrison
+Copyright (c) 2025 Jake Morrison
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.23.0'
+            ModuleVersion = '1.24.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -11,17 +11,17 @@ $modulesToInstall = [System.Collections.ArrayList]::new()
 # https://github.com/pester/Pester
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.4.0'
+            ModuleVersion = '5.7.1'
         }))
 # https://github.com/nightroman/Invoke-Build
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.3'
+            ModuleVersion = '5.12.1'
         }))
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.21.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/actions_bootstrap.ps1
+++ b/actions_bootstrap.ps1
@@ -21,7 +21,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
 # https://github.com/PowerShell/PSScriptAnalyzer
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.24.0'
+            ModuleVersion = '1.23.0'
         }))
 # https://github.com/PowerShell/platyPS
 # older version used due to: https://github.com/PowerShell/platyPS/issues/457

--- a/buildspec_pwsh_linux.yml
+++ b/buildspec_pwsh_linux.yml
@@ -10,7 +10,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      dotnet: 8.0
     commands:
       - pwsh -command './configure_aws_credential.ps1'
       - pwsh -command './install_modules.ps1'

--- a/buildspec_pwsh_windows.yml
+++ b/buildspec_pwsh_windows.yml
@@ -10,7 +10,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-      dotnet: 6.0
+      dotnet: 8.0
     commands:
       - pwsh -command '.\configure_aws_credential.ps1'
       - pwsh -command '.\install_modules.ps1'

--- a/buildspec_pwsh_windows.yml
+++ b/buildspec_pwsh_windows.yml
@@ -9,8 +9,8 @@ version: 0.2
 
 phases:
   install:
-    runtime-versions:
-      dotnet: 8.0
+    # runtime-versions:
+    #   dotnet: 8.0
     commands:
       - pwsh -command '.\configure_aws_credential.ps1'
       - pwsh -command '.\install_modules.ps1'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [26 June 2025]
+
+- Build Updates
+    - Bumped readthedocs resource versions
+
 ## [2.5.4]
 
 - Module Changes

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Pester bumped from `5.5.0` to `5.7.1`
     - InvokeBuild bumped from `5.10.4` to `5.12.1`
     - PSScriptAnalyzer bumped from `1.21.0` to `1.23.0`
+    - AWS Deployment Updates
+        - Updated CodeBuild containers:
+            - `WINDOWS_SERVER_2019_CONTAINER` to `WINDOWS_SERVER_2022_CONTAINER`
+            - `aws/codebuild/windows-base:2019-2.0` to `aws/codebuild/windows-base:2022-1.0`
+            - Updated from  `dotnet6.0` to `dotnet8.0`
 
 ## [2.5.4]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Build Updates
     - Bumped readthedocs resource versions
+    - Pester bumped from `5.5.0` to `5.7.1`
+    - InvokeBuild bumped from `5.10.4` to `5.12.1`
+    - PSScriptAnalyzer bumped from `1.21.0` to `1.23.0`
 
 ## [2.5.4]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             - `WINDOWS_SERVER_2019_CONTAINER` to `WINDOWS_SERVER_2022_CONTAINER`
             - `aws/codebuild/windows-base:2019-2.0` to `aws/codebuild/windows-base:2022-1.0`
             - Updated from  `dotnet6.0` to `dotnet8.0`
+        - Updated `install_modules` to latest versions and AWS.Tools v5.
 
 ## [2.5.4]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Bumped readthedocs resource versions
     - Pester bumped from `5.5.0` to `5.7.1`
     - InvokeBuild bumped from `5.10.4` to `5.12.1`
-    - PSScriptAnalyzer bumped from `1.21.0` to `1.23.0`
+    - PSScriptAnalyzer bumped from `1.21.0` to `1.24.0`
     - AWS Deployment Updates
         - Updated CodeBuild containers:
             - `WINDOWS_SERVER_2019_CONTAINER` to `WINDOWS_SERVER_2022_CONTAINER`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             - Updated from  `dotnet6.0` to `dotnet8.0`
         - Updated `install_modules` to latest versions and AWS.Tools v5.
     - Updated build file to match latest available doc build changes and formatting
+    - Updated all unit and integration tests to support proper Pester 5 formatting requirements
 
 ## [2.5.4]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [26 June 2025]
+## [2.5.6]
+
+- Module Changes
+    - Minor casing changes to support new PSScriptAnalyzer rules
 
 - Build Updates
     - Bumped readthedocs resource versions

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
             - `aws/codebuild/windows-base:2019-2.0` to `aws/codebuild/windows-base:2022-1.0`
             - Updated from  `dotnet6.0` to `dotnet8.0`
         - Updated `install_modules` to latest versions and AWS.Tools v5.
+    - Updated build file to match latest available doc build changes and formatting
 
 ## [2.5.4]
 

--- a/docs/Find-ModuleByCommand.md
+++ b/docs/Find-ModuleByCommand.md
@@ -8,15 +8,18 @@ schema: 2.0.0
 # Find-ModuleByCommand
 
 ## SYNOPSIS
+
 Searches for modules that contain a specific command or cmdlet name.
 
 ## SYNTAX
 
-```
-Find-ModuleByCommand [-CommandName] <String> [-InsightView] [<CommonParameters>]
+```powershell
+Find-ModuleByCommand [-CommandName] <String> [-InsightView]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 The Find-ModuleByCommand cmdlet searches for modules on the PowerShell Gallery that contain a specified command or cmdlet name.
 The cmdlet returns a list of modules that include the command or cmdlet, along with key metrics and information about the module.
 This cmdlet is useful when you need to quickly find a module that includes a particular command or cmdlet, without having to install or download the module first.
@@ -24,21 +27,24 @@ This cmdlet is useful when you need to quickly find a module that includes a par
 ## EXAMPLES
 
 ### EXAMPLE 1
-```
+
+```powershell
 Find-ModuleByCommand -CommandName New-ModuleProject
 ```
 
 Returns a list of modules that contain the command New-ModuleProject
 
 ### EXAMPLE 2
-```
+
+```powershell
 Find-ModuleByCommand -CommandName 'Send-TelegramTextMessage'
 ```
 
 Returns a list of modules that contain the command Send-TelegramTextMessage
 
 ### EXAMPLE 3
-```
+
+```powershell
 Find-ModuleByCommand -CommandName 'Send-TelegramTextMessage' -InsightView
 ```
 
@@ -47,6 +53,7 @@ Returns a list of modules that contain the command Send-TelegramTextMessage, wit
 ## PARAMETERS
 
 ### -CommandName
+
 Specifies the command name to search for
 
 ```yaml
@@ -62,6 +69,7 @@ Accept wildcard characters: False
 ```
 
 ### -InsightView
+
 Output focuses on additional insights available through PSGalleryExplorer.
 This includes the module's size and file count, as well as repository metrics like stars, forks, and last repo update date
 
@@ -78,7 +86,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -86,10 +95,11 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## OUTPUTS
 
 ### PSGEFormat
+
 ## NOTES
+
 Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 
 ## RELATED LINKS
 
 [https://psgalleryexplorer.readthedocs.io/en/latest/Find-ModuleByCommand/](https://psgalleryexplorer.readthedocs.io/en/latest/Find-ModuleByCommand/)
-

--- a/docs/Find-PSGModule.md
+++ b/docs/Find-PSGModule.md
@@ -8,46 +8,55 @@ schema: 2.0.0
 # Find-PSGModule
 
 ## SYNOPSIS
+
 Finds PowerShell Gallery module(s) that match specified criteria.
 
 ## SYNTAX
 
 ### none (Default)
-```
-Find-PSGModule [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>] [-InsightView] [<CommonParameters>]
+
+```powershell
+Find-PSGModule [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>] [-InsightView]
+ [<CommonParameters>]
 ```
 
 ### GalleryDownloads
-```
+
+```powershell
 Find-PSGModule [-ByDownloads] [-ByRandom] [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>]
  [-InsightView] [<CommonParameters>]
 ```
 
 ### Repo
-```
+
+```powershell
 Find-PSGModule [-ByRepoInfo <String>] [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>]
  [-InsightView] [<CommonParameters>]
 ```
 
 ### Update
-```
+
+```powershell
 Find-PSGModule [-ByRecentUpdate <String>] [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>]
  [-InsightView] [<CommonParameters>]
 ```
 
 ### Names
-```
+
+```powershell
 Find-PSGModule [-ByName <String>] [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>] [-InsightView]
  [<CommonParameters>]
 ```
 
 ### Tags
-```
+
+```powershell
 Find-PSGModule [-ByTag <String>] [-IncludeCorps] [-IncludeRegulars] [-NumberToReturn <Int32>] [-InsightView]
  [<CommonParameters>]
 ```
 
 ## DESCRIPTION
+
 Searches PowerShell Gallery for modules and their associated project repositories.
 Results are returned based on provided criteria.
 By default, more common/popular modules and modules made by corporations are excluded.
@@ -58,105 +67,120 @@ Popular modules and corporation modules can be included in results by specifying
 ## EXAMPLES
 
 ### EXAMPLE 1
-```
+
+```powershell
 Find-PSGModule -ByDownloads
 ```
 
 Returns up to 35 modules based on number of PowerShell Gallery downloads.
 
 ### EXAMPLE 2
-```
+
+```powershell
 Find-PSGModule -ByDownloads -IncludeRegulars
 ```
 
 Returns up to 35 modules based on number of PowerShell Gallery downloads including more popular modules.
 
 ### EXAMPLE 3
-```
+
+```powershell
 Find-PSGModule -ByDownloads -IncludeCorps -IncludeRegulars -NumberToReturn 50
 ```
 
 Returns up to 50 modules based on number of PowerShell Gallery downloads including more popular downloads, and modules made by corporations.
 
 ### EXAMPLE 4
-```
+
+```powershell
 Find-PSGModule -ByRepoInfo StarCount
 ```
 
 Returns up to 35 modules based on number of stars the project's repository has.
 
 ### EXAMPLE 5
-```
+
+```powershell
 Find-PSGModule -ByRepoInfo Forks
 ```
 
 Returns up to 35 modules based on number of forks the project's repository has.
 
 ### EXAMPLE 6
-```
+
+```powershell
 Find-PSGModule -ByRepoInfo Issues
 ```
 
 Returns up to 35 modules based on number of issues the project's repository has.
 
 ### EXAMPLE 7
-```
+
+```powershell
 Find-PSGModule -ByRepoInfo Subscribers
 ```
 
 Returns up to 35 modules based on number of subscribers the project's repository has.
 
 ### EXAMPLE 8
-```
+
+```powershell
 Find-PSGModule -ByRecentUpdate GalleryUpdate
 ```
 
 Returns up to 35 modules based on their most recent PowerShell Gallery update.
 
 ### EXAMPLE 9
-```
+
+```powershell
 Find-PSGModule -ByRecentUpdate RepoUpdate
 ```
 
 Returns up to 35 modules based on recent updates to their associated repository.
 
 ### EXAMPLE 10
-```
+
+```powershell
 Find-PSGModule -ByRandom
 ```
 
 Returns up to 35 modules randomly
 
 ### EXAMPLE 11
-```
+
+```powershell
 Find-PSGModule -ByName 'PoshGram'
 ```
 
 Returns module that equals the provided name, if found.
 
 ### EXAMPLE 12
-```
+
+```powershell
 Find-PSGModule -ByName 'Posh*'
 ```
 
 Returns all modules that match the wild card provided name, if found.
 
 ### EXAMPLE 13
-```
+
+```powershell
 Find-PSGModule -ByTag Telegram
 ```
 
 Returns up to 35 modules that contain the tag: Telegram.
 
 ### EXAMPLE 14
-```
+
+```powershell
 Find-PSGModule -ByTag Telegram -IncludeCorps -IncludeRegulars -NumberToReturn 100
 ```
 
 Returns up to 100 modules that contains the tag: Telegram, including more popular modules and modules made by corporations.
 
 ### EXAMPLE 15
-```
+
+```powershell
 $results = Find-PSGModule -ByRepoInfo Watchers -IncludeCorps -IncludeRegulars -NumberToReturn 40
 $results | Format-List
 ```
@@ -166,21 +190,24 @@ It includes more popular modules as well as modules made by corporations.
 A list of results is displayed.
 
 ### EXAMPLE 16
-```
+
+```powershell
 Find-PSGModule
 ```
 
 Returns all non-corp/non-regular modules
 
 ### EXAMPLE 17
-```
+
+```powershell
 Find-PSGModule -IncludeCorps -IncludeRegulars
 ```
 
 Returns all modules
 
 ### EXAMPLE 18
-```
+
+```powershell
 Find-PSGModule -ByTag module -InsightView
 ```
 
@@ -191,6 +218,7 @@ This includes the module's size and file count, as well as repository metrics li
 ## PARAMETERS
 
 ### -ByDownloads
+
 Find modules by number of PowerShell Gallery Downloads
 
 ```yaml
@@ -206,6 +234,7 @@ Accept wildcard characters: False
 ```
 
 ### -ByRepoInfo
+
 Find modules based on various project repository metrics
 
 ```yaml
@@ -221,6 +250,7 @@ Accept wildcard characters: False
 ```
 
 ### -ByRecentUpdate
+
 Find modules based on recent updated to PowerShell Gallery or associated repository
 
 ```yaml
@@ -236,6 +266,7 @@ Accept wildcard characters: False
 ```
 
 ### -ByRandom
+
 Find modules randomly from the PowerShell Gallery
 
 ```yaml
@@ -251,6 +282,7 @@ Accept wildcard characters: False
 ```
 
 ### -ByName
+
 Find module by module name
 
 ```yaml
@@ -266,6 +298,7 @@ Accept wildcard characters: False
 ```
 
 ### -ByTag
+
 Find modules by tag
 
 ```yaml
@@ -281,6 +314,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeCorps
+
 Include modules written by corporations in results
 
 ```yaml
@@ -296,6 +330,7 @@ Accept wildcard characters: False
 ```
 
 ### -IncludeRegulars
+
 Include modules that are well known in results
 
 ```yaml
@@ -311,6 +346,7 @@ Accept wildcard characters: False
 ```
 
 ### -NumberToReturn
+
 Max number of modules to return
 
 ```yaml
@@ -326,6 +362,7 @@ Accept wildcard characters: False
 ```
 
 ### -InsightView
+
 Output focuses on additional insights available through PSGalleryExplorer.
 This includes the module's size and file count, as well as repository metrics like stars, forks, and last repo update date
 
@@ -342,7 +379,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable, -Verbose, -WarningAction, -WarningVariable, and -ProgressAction. 
 For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
@@ -350,10 +388,11 @@ For more information, see about_CommonParameters (http://go.microsoft.com/fwlink
 ## OUTPUTS
 
 ### PSGEFormat
+
 ## NOTES
+
 Author: Jake Morrison - @jakemorrison - https://www.techthoughts.info/
 
 ## RELATED LINKS
 
 [https://psgalleryexplorer.readthedocs.io/en/latest/Find-PSGModule/](https://psgalleryexplorer.readthedocs.io/en/latest/Find-PSGModule/)
-

--- a/docs/PSGalleryExplorer.md
+++ b/docs/PSGalleryExplorer.md
@@ -2,7 +2,7 @@
 Module Name: PSGalleryExplorer
 Module Guid: e9252e8e-2073-4084-9562-cf60ad84603d
 Download Help Link: NA
-Help Version: 2.5.4
+Help Version: 2.5.6
 Locale: en-US
 ---
 
@@ -16,5 +16,3 @@ Searches for modules that contain a specific command or cmdlet name.
 
 ### [Find-PSGModule](Find-PSGModule.md)
 Finds PowerShell Gallery module(s) that match specified criteria.
-
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 # https://github.com/readthedocs-examples/example-mkdocs-basic/blob/main/docs/requirements.txt
 # requirements.txt
-jinja2==3.0.3
-mkdocs>=1.4.2
-mkdocs-material>=9.0.12  #https://github.com/squidfunk/mkdocs-material
-pygments>=2.14.0
+jinja2==3.1.4  #https://pypi.org/project/Jinja2/
+mkdocs>=1.6.0  #https://github.com/mkdocs/mkdocs
+mkdocs-material==9.5.25  #https://github.com/squidfunk/mkdocs-material
+pygments>=2.18.0  #https://pypi.org/project/Pygments/
 # mdx_truly_sane_lists

--- a/install_modules.ps1
+++ b/install_modules.ps1
@@ -45,7 +45,7 @@ $null = $modulesToInstall.Add(([PSCustomObject]@{
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.23.0'
+            ModuleVersion = '1.24.0'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))

--- a/install_modules.ps1
+++ b/install_modules.ps1
@@ -33,19 +33,19 @@ $VerbosePreference = 'SilentlyContinue'
 $modulesToInstall = [System.Collections.ArrayList]::new()
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'Pester'
-            ModuleVersion = '5.5.0'
+            ModuleVersion = '5.7.1'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'InvokeBuild'
-            ModuleVersion = '5.10.4'
+            ModuleVersion = '5.12.1'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))
 $null = $modulesToInstall.Add(([PSCustomObject]@{
             ModuleName    = 'PSScriptAnalyzer'
-            ModuleVersion = '1.21.0'
+            ModuleVersion = '1.23.0'
             BucketName    = 'PSGallery'
             KeyPrefix     = ''
         }))

--- a/src/MarkdownRepair.ps1
+++ b/src/MarkdownRepair.ps1
@@ -1,0 +1,136 @@
+﻿<#
+.SYNOPSIS
+    Repair PlatyPS generated markdown files.
+.NOTES
+    This file is temporarily required to handle platyPS help generation.
+        https://github.com/PowerShell/platyPS/issues/595
+    This is a result of a breaking change introduced in PowerShell 7.4.0:
+        https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-74?view=powershell-7.4
+        Breaking Changes: Added the ProgressAction parameter to the Common Parameters
+    modified from source: https://github.com/PowerShell/platyPS/issues/595#issuecomment-1820971702
+#>
+
+function Remove-CommonParameterFromMarkdown {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '')]
+    <#
+    .SYNOPSIS
+        Remove a PlatyPS generated parameter block.
+    .DESCRIPTION
+        Removes parameter block for the provided parameter name from the markdown file provided.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($param in $ParameterName) {
+            if (-not ($Param.StartsWith('-'))) {
+                $param = "-$($param)"
+            }
+            # Remove the parameter block
+            $pattern = "(?m)^### $param\r?\n[\S\s]*?(?=#{2,3}?)"
+            $newContent = $content -replace $pattern, ''
+            # Remove the parameter from the syntax block
+            $pattern = " \[$param\s?.*?]"
+            $newContent = $newContent -replace $pattern, ''
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $param to $p"
+                # Update file content
+                $content = $newContent
+                $updateFile = $true
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Add-MissingCommonParameterToMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter(Mandatory = $false)]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    foreach ($p in $Path) {
+        $content = (Get-Content -Path $p -Raw).TrimEnd()
+        $updateFile = $false
+        foreach ($NewParameter in $ParameterName) {
+            if (-not ($NewParameter.StartsWith('-'))) {
+                $NewParameter = "-$($NewParameter)"
+            }
+            $pattern = '(?m)^This cmdlet supports the common parameters:(.+?)\.'
+            $replacement = {
+                $Params = $_.Groups[1].Captures[0].ToString() -split ' '
+                $CommonParameters = @()
+                foreach ($CommonParameter in $Params) {
+                    if ($CommonParameter.StartsWith('-')) {
+                        if ($CommonParameter.EndsWith(',')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        elseif ($p.EndsWith('.')) {
+                            $CleanParam = $CommonParameter.Substring(0, $CommonParameter.Length - 1)
+                        }
+                        else {
+                            $CleanParam = $CommonParameter
+                        }
+                        $CommonParameters += $CleanParam
+                    }
+                }
+                if ($NewParameter -notin $CommonParameters) {
+                    $CommonParameters += $NewParameter
+                }
+                $CommonParameters[-1] = "and $($CommonParameters[-1]). "
+                return "This cmdlet supports the common parameters: " + (($CommonParameters | Sort-Object) -join ', ')
+            }
+            $newContent = $content -replace $pattern, $replacement
+            if ($null -ne (Compare-Object -ReferenceObject $content -DifferenceObject $newContent)) {
+                Write-Verbose "Added $NewParameter to $p"
+                $updateFile = $true
+                $content = $newContent
+            }
+        }
+        # Save file if content has changed
+        if ($updateFile) {
+            $newContent | Out-File -Encoding utf8 -FilePath $p
+            Write-Verbose "Updated file: $p"
+        }
+    }
+    return
+}
+
+function Repair-PlatyPSMarkdown {
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $Path,
+
+        [Parameter()]
+        [string[]]
+        $ParameterName = @('ProgressAction')
+    )
+    $ErrorActionPreference = 'Stop'
+    $Parameters = @{
+        Path          = $Path
+        ParameterName = $ParameterName
+    }
+    $null = Remove-CommonParameterFromMarkdown @Parameters
+    $null = Add-MissingCommonParameterToMarkdown @Parameters
+    return
+}

--- a/src/PSGalleryExplorer.build.ps1
+++ b/src/PSGalleryExplorer.build.ps1
@@ -38,7 +38,7 @@
 #>
 
 #Include: Settings
-$ModuleName = (Split-Path -Path $BuildFile -Leaf).Split('.')[0]
+$ModuleName = [regex]::Match((Get-Item $BuildFile).Name, '^(.*)\.build\.ps1$').Groups[1].Value
 . "./$ModuleName.Settings.ps1"
 
 function Test-ManifestBool ($Path) {
@@ -67,7 +67,7 @@ Add-BuildTask BuildNoIntegration -Jobs $str2
 
 # Pre-build variables to be used by other portions of the script
 Enter-Build {
-    $script:ModuleName = (Split-Path -Path $BuildFile -Leaf).Split('.')[0]
+    $script:ModuleName = [regex]::Match((Get-Item $BuildFile).Name, '^(.*)\.build\.ps1$').Groups[1].Value
 
     # Identify other required paths
     $script:ModuleSourcePath = Join-Path -Path $BuildRoot -ChildPath $script:ModuleName
@@ -90,7 +90,7 @@ Enter-Build {
     $script:BuildModuleRootFile = Join-Path -Path $script:ArtifactsPath -ChildPath "$($script:ModuleName).psm1"
 
     # Ensure our builds fail until if below a minimum defined code test coverage threshold
-    $script:coverageThreshold = 30
+    $script:coverageThreshold = 95
 
     [version]$script:MinPesterVersion = '5.2.2'
     [version]$script:MaxPesterVersion = '5.99.99'
@@ -142,6 +142,7 @@ Add-BuildTask ImportModuleManifest {
         Import-Module $script:ModuleManifestFile -Force -PassThru -ErrorAction Stop
     }
     catch {
+        Write-Build Red "      ...$_`n"
         throw 'Unable to load the project module'
     }
     Write-Build Green "      ...$script:ModuleName imported successfully"
@@ -238,7 +239,7 @@ Add-BuildTask FormattingCheck {
 Add-BuildTask Test {
 
     Write-Build White "      Importing desired Pester version. Min: $script:MinPesterVersion Max: $script:MaxPesterVersion"
-    Remove-Module -Name Pester -Force -ErrorAction SilentlyContinue # there are instances where some containers have Pester already in the session
+    Remove-Module -Name Pester -Force -ErrorAction 'SilentlyContinue'# there are instances where some containers have Pester already in the session
     Import-Module -Name Pester -MinimumVersion $script:MinPesterVersion -MaximumVersion $script:MaxPesterVersion -ErrorAction 'Stop'
 
     $codeCovPath = "$script:ArtifactsPath\ccReport\"
@@ -354,7 +355,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
     Write-Build Gray '           ...Markdown generation completed.'
 
     Write-Build Gray '           Replacing markdown elements...'
-    # Replace multi-line EXAMPLES
+    Write-Build DarkGray '             Replace multi-line EXAMPLES'
     $OutputDir = "$script:ArtifactsPath\docs\"
     $OutputDir | Get-ChildItem -File | ForEach-Object {
         # fix formatting in multiline examples
@@ -364,7 +365,7 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
             Set-Content -Path $_.FullName -Value $newContent -Force
         }
     }
-    # Replace each missing element we need for a proper generic module page .md file
+    Write-Build DarkGray '             Replace each missing element we need for a proper generic module page .md file'
     $ModulePageFileContent = Get-Content -Raw $ModulePage
     $ModulePageFileContent = $ModulePageFileContent -replace '{{Manually Enter Description Here}}', $script:ModuleDescription
     $script:FunctionsToExport | ForEach-Object {
@@ -373,6 +374,27 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
         $ReplacementText = (Get-Help -Detailed $_).Synopsis
         $ModulePageFileContent = $ModulePageFileContent -replace $TextToReplace, $ReplacementText
     }
+    Write-Build DarkGray '             Evaluating if running 7.4.0 or higher...'
+    # https://github.com/PowerShell/platyPS/issues/595
+    if ($PSVersionTable.PSVersion -ge [version]'7.4.0') {
+        Write-Build DarkGray '                Performing Markdown repair'
+        # dot source markdown repair
+        . $BuildRoot\MarkdownRepair.ps1
+        $OutputDir | Get-ChildItem -File | ForEach-Object {
+            Repair-PlatyPSMarkdown -Path $_.FullName
+        }
+    }
+    Write-Build DarkGray '             Add blank line after headers.'
+    $OutputDir | Get-ChildItem -File | ForEach-Object {
+        $content = Get-Content $_.FullName -Raw
+        $newContent = $content -replace '(?m)^(#{1,6}\s+.*)$\r?\n(?!\r?\n)', "`$1`r`n"
+        # $newContent = $content -replace '(?m)^(#{1,6}\s+.+?)$\r?\n(?!\r?\n)', "`$1`n"
+        # $newContent = $content -replace '(?m)^(#{1,6}\s+.*)$\r?\n(?!\r?\n)', "`$1`n"
+        if ($newContent -ne $content) {
+            Set-Content -Path $_.FullName -Value $newContent -Force
+        }
+    }
+    # *NOTE: it is not possible to adjust fenced code block at this location as conversion to MAML does not support language tags.
 
     $ModulePageFileContent | Out-File $ModulePage -Force -Encoding:utf8
     Write-Build Gray '           ...Markdown replacements complete.'
@@ -397,7 +419,8 @@ Add-BuildTask CreateMarkdownHelp -After CreateHelpStart {
 
     Write-Build Gray '           Checking for missing SYNOPSIS in md files...'
     $fSynopsisOutput = @()
-    $synopsisEval = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "^## SYNOPSIS$" -Context 0, 1
+    # $synopsisEval = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "^## SYNOPSIS$" -Context 0, 1
+    $synopsisEval = Select-String -Path "$script:ArtifactsPath\docs\*.md" -Pattern "^## SYNOPSIS$\r?\n$" -Context 0, 2
     $synopsisEval | ForEach-Object {
         $chAC = $_.Context.DisplayPostContext.ToCharArray()
         if ($null -eq $chAC) {
@@ -421,6 +444,57 @@ Add-BuildTask CreateExternalHelp -After CreateMarkdownHelp {
 } #CreateExternalHelp
 
 Add-BuildTask CreateHelpComplete -After CreateExternalHelp {
+    Write-Build Gray '           Finalizing markdown documentation now that external help has been created...'
+    Write-Build DarkGray '             Add powershell language to unspecified fenced code blocks.'
+
+    $OutputDir = "$script:ArtifactsPath\docs\"
+
+    Get-ChildItem -Path $OutputDir -File | ForEach-Object {
+        $lines = Get-Content -Path $_.FullName
+        $insideCodeBlock = $false
+
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            # Regex captures everything after triple backticks (if present).
+            # e.g. ```yaml => captured group = "yaml"
+            #      ```    => captured group = ""
+            if ($lines[$i] -match '^\s*```(\S*)\s*$') {
+                $lang = $Matches[1]
+
+                if (-not $insideCodeBlock) {
+                    # We found an opening fence
+                    if ([string]::IsNullOrWhiteSpace($lang)) {
+                        # Bare triple backticks => add powershell
+                        $lines[$i] = '```powershell'
+                    }
+                    # Toggle "inside code block" on
+                    $insideCodeBlock = $true
+                }
+                else {
+                    # We found the closing fence -> set $insideCodeBlock off
+                    $insideCodeBlock = $false
+                    # Do *not* modify closing fence, leave it exactly as it is
+                }
+            }
+        }
+
+        Set-Content -Path $_.FullName -Value $lines
+    }
+    Write-Build DarkGray '             Ensuring exactly one trailing newline in final markdown file.'
+    Get-ChildItem -Path $OutputDir -File -Filter *.md | ForEach-Object {
+        # Read the file as an array of lines
+        $lines = Get-Content -Path $_.FullName
+
+        # Remove all blank lines at the end, but do not remove actual content
+        while ($lines.Count -gt 0 -and $lines[-1] -match '^\s*$') {
+            $lines = $lines[0..($lines.Count - 2)]
+        }
+
+        # Re-join with Windows line endings and add exactly one trailing newline
+        $content = ($lines -join "`r`n")
+        Set-Content -Path $_.FullName -Value $content -Force
+    }
+    Write-Build Gray '           ...Markdown documentation finalized.'
+
     Write-Build Green '      ...CreateHelp Complete!'
 } #CreateHelpStart
 
@@ -468,6 +542,8 @@ Add-BuildTask Build {
         $null = $scriptContent.AppendLine('')
     }
     $scriptContent.ToString() | Out-File -FilePath $script:BuildModuleRootFile -Encoding utf8 -Force
+    # Cleanup the combined root module and remove extra trailing lines at the end of the file.
+    Invoke-Formatter $script:BuildModuleRootFile -ErrorAction SilentlyContinue
     Write-Build Gray '        ...Module creation complete.'
 
     Write-Build Gray '        Cleaning up leftover artifacts...'

--- a/src/PSGalleryExplorer/PSGalleryExplorer.psd1
+++ b/src/PSGalleryExplorer/PSGalleryExplorer.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'PSGalleryExplorer.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '2.5.4'
+    ModuleVersion     = '2.5.6'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/PSGalleryExplorer/Private/Import-XMLDataSet.ps1
+++ b/src/PSGalleryExplorer/Private/Import-XMLDataSet.ps1
@@ -16,6 +16,7 @@
     PSGalleryExplorer
 #>
 function Import-XMLDataSet {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCorrectCasing', '', Justification = 'ConvertFrom-Clixml is used in more than one module with different casing requirements.')]
     [CmdletBinding()]
     param (
     )
@@ -31,7 +32,7 @@ function Import-XMLDataSet {
                     ErrorAction = 'Stop'
                 }
                 $fileData = Get-Content @getContentSplat
-                $script:glData = $fileData | ConvertFrom-CliXml -ErrorAction Stop
+                $script:glData = $fileData | ConvertFrom-Clixml -ErrorAction Stop
             } #try
             catch {
                 $result = $false

--- a/src/PSGalleryExplorer/Private/Import-XMLDataSet.ps1
+++ b/src/PSGalleryExplorer/Private/Import-XMLDataSet.ps1
@@ -31,7 +31,7 @@ function Import-XMLDataSet {
                     ErrorAction = 'Stop'
                 }
                 $fileData = Get-Content @getContentSplat
-                $script:glData = $fileData | ConvertFrom-Clixml -ErrorAction Stop
+                $script:glData = $fileData | ConvertFrom-CliXml -ErrorAction Stop
             } #try
             catch {
                 $result = $false

--- a/src/PSGalleryExplorer/Private/Invoke-XMLDataCheck.ps1
+++ b/src/PSGalleryExplorer/Private/Invoke-XMLDataCheck.ps1
@@ -25,7 +25,7 @@ function Invoke-XMLDataCheck {
             HelpMessage = 'Skip confirmation')]
         [switch]$Force
     )
-    Begin {
+    begin {
 
         if (-not $PSBoundParameters.ContainsKey('Verbose')) {
             $VerbosePreference = $PSCmdlet.SessionState.PSVariable.GetValue('VerbosePreference')
@@ -41,7 +41,7 @@ function Invoke-XMLDataCheck {
 
         $results = $true #assume the best
     } #begin
-    Process {
+    process {
         # -Confirm --> $ConfirmPreference = 'Low'
         # ShouldProcess intercepts WhatIf* --> no need to pass it on
         if ($Force -or $PSCmdlet.ShouldProcess("ShouldProcess?")) {
@@ -76,7 +76,7 @@ function Invoke-XMLDataCheck {
 
         } #if_Should
     } #process
-    End {
+    end {
         return $results
     } #end
 } #Invoke-XMLDataCheck

--- a/src/Tests/Integration/PSGalleryExplorer.Tests.ps1
+++ b/src/Tests/Integration/PSGalleryExplorer.Tests.ps1
@@ -1,14 +1,12 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-#-------------------------------------------------------------------------
-#if the module is already in memory, remove it
-Get-Module $ModuleName | Remove-Module -Force
-$PathToManifest = [System.IO.Path]::Combine('..', '..', 'Artifacts', "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', 'Artifacts', "$ModuleName.psd1")
+    #if the module is already in memory, remove it
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
+}
+
 Describe 'Integration Tests' -Tag Integration {
 
     Context -Name 'Find-PSGModule' {

--- a/src/Tests/Integration/PSGalleryExplorer.Tests.ps1
+++ b/src/Tests/Integration/PSGalleryExplorer.Tests.ps1
@@ -14,23 +14,23 @@ Describe 'Integration Tests' -Tag Integration {
         Context 'General' {
 
             It 'should support the InSightview parameter' {
-                $eval = Find-PSGModule -ByName 'Catesta' -InSightview
-                $eval.Name | Should -BeExactly 'Catesta'
+                $eval = Find-PSGModule -ByName 'pwshBedrock' -InSightview
+                $eval.Name | Should -BeExactly 'pwshBedrock'
             } #it
 
             It 'should have the ModuleSize property' {
-                $eval = Find-PSGModule -ByName 'Catesta'
+                $eval = Find-PSGModule -ByName 'pwshBedrock'
                 $eval.ModuleSize | Should -BeGreaterThan 0
             } #it
 
             It 'should have the ModuleFileCount property' {
-                $eval = Find-PSGModule -ByName 'Catesta'
+                $eval = Find-PSGModule -ByName 'pwshBedrock'
                 $eval.ModuleFileCount | Should -BeGreaterThan 0
             } #it
 
             It 'should have the Dependency property populated' {
-                $eval = Find-PSGModule -ByName 'Catesta'
-                $eval.Dependencies.Count | Should -BeGreaterThan 4
+                $eval = Find-PSGModule -ByName 'pwshBedrock'
+                $eval.Dependencies.Count | Should -BeGreaterThan 3
             } #it
 
         } #context_General

--- a/src/Tests/Unit/ExportedFunctions.Tests.ps1
+++ b/src/Tests/Unit/ExportedFunctions.Tests.ps1
@@ -1,17 +1,14 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
-    #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
-}
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
-
 BeforeAll {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', $ModuleName, "$ModuleName.psd1")
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
+    $manifestContent = Test-ModuleManifest -Path $PathToManifest
+    $moduleExported = Get-Command -Module $ModuleName | Select-Object -ExpandProperty Name
+    $manifestExported = ($manifestContent.ExportedFunctions).Keys
+}
+BeforeDiscovery {
     Set-Location -Path $PSScriptRoot
     $ModuleName = 'PSGalleryExplorer'
     $PathToManifest = [System.IO.Path]::Combine('..', '..', $ModuleName, "$ModuleName.psd1")
@@ -24,43 +21,40 @@ Describe $ModuleName {
     Context 'Exported Commands' -Fixture {
 
         Context 'Number of commands' -Fixture {
-            It -Name 'Exports the same number of public functions as what is listed in the Module Manifest' -Test {
+
+            It 'Exports the same number of public functions as what is listed in the Module Manifest' {
                 $manifestExported.Count | Should -BeExactly $moduleExported.Count
             }
+
         }
 
-        Context 'Explicitly exported commands' -ForEach $moduleExported {
-            foreach ($command in $moduleExported) {
-                BeforeAll {
-                    $command = $_
-                }
-                It -Name "Includes the $command in the Module Manifest ExportedFunctions" -Test {
-                    $manifestExported -contains $command | Should -BeTrue
-                }
+        Context 'Explicitly exported commands' {
+
+            It 'Includes <_> in the Module Manifest ExportedFunctions' -ForEach $moduleExported {
+                $manifestExported -contains $_ | Should -BeTrue
             }
-        }
-    }
 
-    Context 'Command Help' -ForEach $moduleExported {
-        foreach ($command in $moduleExported) {
-            BeforeAll {
+        }
+    } #context_ExportedCommands
+
+    Context 'Command Help' -Fixture {
+        Context '<_>' -Foreach $moduleExported {
+
+            BeforeEach {
                 $help = Get-Help -Name $_ -Full
             }
-            Context $command -Fixture {
-                $help = Get-Help -Name $command -Full
 
-                It -Name 'Includes a Synopsis' -Test {
-                    $help.Synopsis | Should -Not -BeNullOrEmpty
-                }
+            It -Name 'Includes a Synopsis' -Test {
+                $help.Synopsis | Should -Not -BeNullOrEmpty
+            }
 
-                It -Name 'Includes a Description' -Test {
-                    $help.description.Text | Should -Not -BeNullOrEmpty
-                }
+            It -Name 'Includes a Description' -Test {
+                $help.description.Text | Should -Not -BeNullOrEmpty
+            }
 
-                It -Name 'Includes an Example' -Test {
-                    $help.examples.example | Should -Not -BeNullOrEmpty
-                }
+            It -Name 'Includes an Example' -Test {
+                $help.examples.example | Should -Not -BeNullOrEmpty
             }
         }
-    }
+    } #context_CommandHelp
 }

--- a/src/Tests/Unit/Private/Confirm-DataLocation.Tests.ps1
+++ b/src/Tests/Unit/Private/Confirm-DataLocation.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Private/Confirm-MetadataUpdate.Tests.ps1
+++ b/src/Tests/Unit/Private/Confirm-MetadataUpdate.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Private/Confirm-XMLDataSet.Tests.ps1
+++ b/src/Tests/Unit/Private/Confirm-XMLDataSet.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Private/Expand-XMLDataSet.Tests.ps1
+++ b/src/Tests/Unit/Private/Expand-XMLDataSet.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Private/Get-RemoteFile.Tests.ps1
+++ b/src/Tests/Unit/Private/Get-RemoteFile.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Private/Import-XMLDataSet.Tests.ps1
+++ b/src/Tests/Unit/Private/Import-XMLDataSet.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Private/Invoke-XMLDataCheck.Tests.ps1
+++ b/src/Tests/Unit/Private/Invoke-XMLDataCheck.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Public/Find-ModuleByCommand.Tests.ps1
+++ b/src/Tests/Unit/Public/Find-ModuleByCommand.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 

--- a/src/Tests/Unit/Public/Find-PSGModule.Tests.ps1
+++ b/src/Tests/Unit/Public/Find-PSGModule.Tests.ps1
@@ -1,15 +1,11 @@
-#-------------------------------------------------------------------------
-Set-Location -Path $PSScriptRoot
-#-------------------------------------------------------------------------
-$ModuleName = 'PSGalleryExplorer'
-$PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
-#-------------------------------------------------------------------------
-if (Get-Module -Name $ModuleName -ErrorAction 'SilentlyContinue') {
+BeforeDiscovery {
+    Set-Location -Path $PSScriptRoot
+    $ModuleName = 'PSGalleryExplorer'
+    $PathToManifest = [System.IO.Path]::Combine('..', '..', '..', $ModuleName, "$ModuleName.psd1")
     #if the module is already in memory, remove it
-    Remove-Module -Name $ModuleName -Force
+    Get-Module $ModuleName -ErrorAction SilentlyContinue | Remove-Module -Force
+    Import-Module $PathToManifest -Force
 }
-Import-Module $PathToManifest -Force
-#-------------------------------------------------------------------------
 
 InModuleScope 'PSGalleryExplorer' {
 


### PR DESCRIPTION
# Pull Request

## Description

- Module Changes
    - Minor casing changes to support new PSScriptAnalyzer rules

- Build Updates
    - Bumped readthedocs resource versions
    - Pester bumped from `5.5.0` to `5.7.1`
    - InvokeBuild bumped from `5.10.4` to `5.12.1`
    - PSScriptAnalyzer bumped from `1.21.0` to `1.24.0`
    - AWS Deployment Updates
        - Updated CodeBuild containers:
            - `WINDOWS_SERVER_2019_CONTAINER` to `WINDOWS_SERVER_2022_CONTAINER`
            - `aws/codebuild/windows-base:2019-2.0` to `aws/codebuild/windows-base:2022-1.0`
            - Updated from  `dotnet6.0` to `dotnet8.0`
        - Updated `install_modules` to latest versions and AWS.Tools v5.
    - Updated build file to match latest available doc build changes and formatting
    - Updated all unit and integration tests to support proper Pester 5 formatting requirements

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the projects associated license.
